### PR TITLE
feat : 자기소개서 작성 페이지 UI

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Layout from "/src/components/Layout/index.jsx";
 import HomePage from "/src/pages/HomePage.jsx";
 import ExperienceSheetPage from "./pages/ExperienceSheetPage";
+import WriteLetterPage from "/src/pages/WriteLetterPage.jsx";
 
 const Router = () => {
   return (
@@ -9,7 +10,8 @@ const Router = () => {
       <Routes>
         <Route element={<Layout />}>
           <Route path="/" element={<HomePage />} />
-          <Route path="/sheet-list" element={<ExperienceSheetPage />} />
+          <Route path="/experience-sheet" element={<ExperienceSheetPage />} />
+          <Route path="/write-letter" element={<WriteLetterPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/Layout/Header/index.jsx
+++ b/src/components/Layout/Header/index.jsx
@@ -7,8 +7,8 @@ const Header = () => {
     <Container>
       <Nav>
         <Logo src={LogoImage} alt="Logo" />
-        <NavItemContainer path={"/"}>채용공고</NavItemContainer>
-        <NavItemContainer path={"/sheet-list"}>자기소개서</NavItemContainer>
+        <NavItemContainer path={"/experience-sheet"}>경험시트</NavItemContainer>
+        <NavItemContainer path={"/write-letter"}>자기소개서</NavItemContainer>
         <NavItemContainer path={"/"}>AI 면접</NavItemContainer>
         <NavItemContainer path={"/"}>도식화</NavItemContainer>
         <NavItemContainer path={"/"}>

--- a/src/components/write-letter/DetailPanel.jsx
+++ b/src/components/write-letter/DetailPanel.jsx
@@ -1,0 +1,106 @@
+import styled from "styled-components";
+
+function DetailPanel() {
+  return (
+    <Container>
+      <TopContainer>
+        <TitleText>2024 1학기 파이썬 강의</TitleText>
+        <Date>2024.10.10 - 2024.11.10</Date>
+      </TopContainer>
+      <MainContainer>
+        <TagContainer>
+          <TitleTag>리더십</TitleTag>
+          <Tag>창의력</Tag>
+          <Tag>도전</Tag>
+          <Tag>열정</Tag>
+        </TagContainer>
+        <TextBox>
+          팀 프로젝트에서 발생한 갈등, 2024-1학기에 수강한 파이썬 전공강의에서
+          팀 프로젝트 과제가 주어졌습니다. 프로젝트 주제는 데이터를 분석해 의미
+          있는 결과를 도출하는 것이었는데, 팀원 간 역할 분담 문제와 코드 작성
+          방식에 대한 의견 충돌로 인해 초기 진행이 지연되었습니다. 특히, 서로의
+          의견을 이해하려는 노력보다는 자신의 주장만을 강조하는 분위기가
+          형성되어 프로젝트의 방향성이 흔들렸습니다.
+        </TextBox>
+      </MainContainer>
+    </Container>
+  );
+}
+
+export default DetailPanel;
+
+const Container = styled.div`
+  width: 380px;
+  height: 200px;
+
+  background-color: var(--color-bg-blue);
+  border-radius: 15px;
+  border: 1px solid var(--color-light-gray);
+  padding: 20px;
+`;
+
+const TitleText = styled.p`
+  font-size: 14px;
+  font-weight: var(--weight-bold);
+`;
+
+const Date = styled.p`
+  font-size: 14px;
+  font-weight: var(--weight-regular);
+  color: var(--color-gray);
+`;
+
+const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+  font-size: 10px;
+  padding: 10px;
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const TitleTag = styled.div`
+  width: fit-content;
+  border-radius: 4px;
+
+  font-weight: var(--weight-bold);
+  padding: 5px;
+
+  background-color: var(--color-dark-blue);
+  color: white;
+`;
+
+const Tag = styled.div`
+  width: fit-content;
+  border-radius: 4px;
+
+  font-size: 10px;
+  font-weight: var(--weight-medium);
+  padding: 5px;
+
+  background-color: var(--color-light-blue);
+  color: var(--color-navy);
+`;
+
+const MainContainer = styled.div`
+  width: 100%;
+  height: 180px;
+  background-color: white;
+  border-radius: 10px;
+`;
+
+const TextBox = styled.div`
+  color: var(--color-gray);
+  font-size: 12px;
+  line-height: 16px;
+  padding: 0 10px;
+`;

--- a/src/components/write-letter/IndexNavigator.jsx
+++ b/src/components/write-letter/IndexNavigator.jsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+
+function IndexNavigator({ onNavigate }) {
+  return (
+    <Container>
+      <Text onClick={() => onNavigate(1)}>1. 지원동기</Text>
+      <Text onClick={() => onNavigate(2)}>2. 직무역량</Text>
+      <Text onClick={() => onNavigate(3)}>3. 도전</Text>
+      <Text onClick={() => onNavigate(4)}>4. 창의성</Text>
+      <Text onClick={() => onNavigate(5)}>5. 팀워크 / 협업</Text>
+    </Container>
+  );
+}
+
+export default IndexNavigator;
+
+const Container = styled.div`
+  position: fixed;
+  top: 80px;
+  left: 120px;
+  width: 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background-color: white;
+  border-radius: 8px;
+  z-index: 100;
+  overflow-x: hidden;
+`;
+
+const Text = styled.p`
+  font-size: 12px;
+  font-weight: var(--weight-semi-bold);
+  color: var(--color-dark-gray);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--color-dark-blue);
+  }
+`;

--- a/src/components/write-letter/LetterBox.jsx
+++ b/src/components/write-letter/LetterBox.jsx
@@ -15,12 +15,7 @@ function LetterBox({ title, subText, text, maxLength, onChange }) {
           </CountLetter>
         </TitleContainer>
         <SubText>{subText}</SubText>
-        <TextBox
-          value={text}
-          onChange={handleChange}
-          maxLength={maxLength}
-          subText={subText}
-        />
+        <TextBox value={text} onChange={handleChange} maxLength={maxLength} />
       </LetterContainer>
     </Container>
   );

--- a/src/components/write-letter/LetterBox.jsx
+++ b/src/components/write-letter/LetterBox.jsx
@@ -1,0 +1,93 @@
+import styled from "styled-components";
+
+function LetterBox({ title, subText, text, maxLength, onChange }) {
+  const handleChange = (e) => {
+    onChange(e.target.value);
+  };
+
+  return (
+    <Container>
+      <LetterContainer>
+        <TitleContainer>
+          <TitleText>{title}</TitleText>
+          <CountLetter>
+            {text.length} / {maxLength}
+          </CountLetter>
+        </TitleContainer>
+        <SubText>{subText}</SubText>
+        <TextBox
+          value={text}
+          onChange={handleChange}
+          maxLength={maxLength}
+          subText={subText}
+        />
+      </LetterContainer>
+    </Container>
+  );
+}
+
+export default LetterBox;
+
+const Container = styled.div`
+  display: flex;
+
+  padding-left: 140px;
+`;
+
+const LetterContainer = styled.div`
+  width: 500px;
+  height: 140px;
+
+  background-color: var(--color-bg-blue);
+
+  border-radius: 12px;
+  border: 0.5px solid var(--color-light-gray);
+  padding: 20px;
+  margin-bottom: 20px;
+`;
+
+const TitleContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const TitleText = styled.p`
+  font-size: 14px;
+  font-weight: var(--weight-bold);
+  margin-bottom: 5px;
+`;
+
+const SubText = styled.p`
+  font-size: 12px;
+  font-weight: var(--weight-regular);
+  line-height: 15px;
+  margin-bottom: 20px;
+
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+`;
+
+const CountLetter = styled.p`
+  font-size: 12px;
+  font-weight: var(--weight-regular);
+`;
+
+const TextBox = styled.textarea`
+  width: 100%;
+  background-color: white;
+
+  border: 1px solid var(--color-light-gray);
+  border-radius: 8px;
+
+  font-size: 14px;
+  font-weight: var(--weight-regular);
+  color: var(--color-black);
+
+  resize: none;
+
+  line-height: 1.5;
+  padding: 10px;
+  box-sizing: border-box;
+  overflow-y: auto;
+`;

--- a/src/components/write-letter/PreviewNewsCard.jsx
+++ b/src/components/write-letter/PreviewNewsCard.jsx
@@ -1,0 +1,179 @@
+import styled from "styled-components";
+import { useState } from "react";
+import { FaCheck } from "react-icons/fa6";
+
+function PreviewNewsCard() {
+  const [isChecked, setIsChecked] = useState(false);
+
+  const handleCheckboxClick = () => {
+    setIsChecked(!isChecked);
+  };
+
+  return (
+    <Container>
+      <CardContainer>
+        <TopContainer>
+          <TitleText>데이터 분석 워크샵</TitleText>
+          <CheckBox onClick={handleCheckboxClick}>
+            <CheckInput type="checkbox" checked={isChecked} readOnly />
+            <CheckMark isChecked={isChecked}>
+              {isChecked && <FaCheck />}
+            </CheckMark>
+          </CheckBox>
+        </TopContainer>
+        <TagContainer>
+          <TitleTag>워크샵</TitleTag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+        </TagContainer>
+      </CardContainer>
+      <CardContainer>
+        <TopContainer>
+          <TitleText>데이터 분석 워크샵</TitleText>
+          <CheckBox onClick={handleCheckboxClick}>
+            <CheckInput type="checkbox" checked={isChecked} readOnly />
+            <CheckMark isChecked={isChecked}>
+              {isChecked && <FaCheck />}
+            </CheckMark>
+          </CheckBox>
+        </TopContainer>
+        <TagContainer>
+          <TitleTag>워크샵</TitleTag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+        </TagContainer>
+      </CardContainer>
+      <CardContainer>
+        <TopContainer>
+          <TitleText>데이터 분석 워크샵</TitleText>
+          <CheckBox onClick={handleCheckboxClick}>
+            <CheckInput type="checkbox" checked={isChecked} readOnly />
+            <CheckMark isChecked={isChecked}>
+              {isChecked && <FaCheck />}
+            </CheckMark>
+          </CheckBox>
+        </TopContainer>
+        <TagContainer>
+          <TitleTag>워크샵</TitleTag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+        </TagContainer>
+      </CardContainer>
+      <CardContainer>
+        <TopContainer>
+          <TitleText>데이터 분석 워크샵</TitleText>
+          <CheckBox onClick={handleCheckboxClick}>
+            <CheckInput type="checkbox" checked={isChecked} readOnly />
+            <CheckMark isChecked={isChecked}>
+              {isChecked && <FaCheck />}
+            </CheckMark>
+          </CheckBox>
+        </TopContainer>
+        <TagContainer>
+          <TitleTag>워크샵</TitleTag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+          <Tag>리더십</Tag>
+        </TagContainer>
+      </CardContainer>
+    </Container>
+  );
+}
+
+export default PreviewNewsCard;
+
+const Container = styled.div`
+  width: 160px;
+
+  background-color: white;
+  border-radius: 12px;
+
+  border: 1px solid var(--color-light-gray);
+  padding: 15px;
+`;
+
+const CardContainer = styled.div`
+  width: 100%;
+`;
+
+const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TitleText = styled.p`
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+`;
+
+const CheckBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+`;
+
+const CheckInput = styled.input`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+`;
+
+const CheckMark = styled.div`
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--color-gray);
+  border-radius: 4px;
+  background-color: ${(props) =>
+    props.isChecked ? "var(--color-dark-blue)" : "transparent"};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+
+  svg {
+    font-size: 10px;
+  }
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+  font-size: 10px;
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const TitleTag = styled.div`
+  width: fit-content;
+  border-radius: 4px;
+
+  font-weight: var(--weight-bold);
+  padding: 5px;
+
+  background-color: var(--color-dark-blue);
+  color: white;
+`;
+
+const Tag = styled.div`
+  width: fit-content;
+  border-radius: 4px;
+
+  font-weight: var(--weight-medium);
+  padding: 5px;
+
+  background-color: var(--color-light-blue);
+  color: var(--color-navy);
+`;

--- a/src/components/write-letter/PreviewSheetCard.jsx
+++ b/src/components/write-letter/PreviewSheetCard.jsx
@@ -3,41 +3,72 @@ import { useState } from "react";
 import { FaCheck } from "react-icons/fa6";
 
 function PreviewSheetCard() {
-  const [isChecked, setIsChecked] = useState(false);
+  const [cards, setCards] = useState([
+    {
+      id: 1,
+      title: "데이터 분석 워크샵",
+      tags: ["워크샵", "리더십", "팀워크"],
+      $isChecked: false,
+    },
+    {
+      id: 2,
+      title: "대한전기학회 워크샵",
+      tags: ["워크샵", "창의성", "문제해결"],
+      $isChecked: false,
+    },
+    {
+      id: 3,
+      title: "프로그래밍 스터디",
+      tags: ["스터디", "개발", "협업"],
+      $isChecked: false,
+    },
+  ]);
 
-  const handleCheckboxClick = () => {
-    setIsChecked(!isChecked);
+  const handleCheckboxClick = (id) => {
+    setCards((prevCards) =>
+      prevCards.map((card) =>
+        card.id === id ? { ...card, $isChecked: !card.$isChecked } : card
+      )
+    );
   };
 
   return (
-    <Container>
-      <TopContainer>
-        <TitleText>데이터 분석 워크샵</TitleText>
-        <CheckBox onClick={handleCheckboxClick}>
-          <CheckInput type="checkbox" checked={isChecked} readOnly />
-          <CheckMark isChecked={isChecked}>
-            {isChecked && <FaCheck />}
-          </CheckMark>
-        </CheckBox>
-      </TopContainer>
-      <TagContainer>
-        <TitleTag>워크샵</TitleTag>
-        <Tag>리더십</Tag>
-        <Tag>리더십</Tag>
-        <Tag>리더십</Tag>
-      </TagContainer>
-    </Container>
+    <Background>
+      {cards.map((card) => (
+        <Container key={card.id}>
+          <TopContainer>
+            <TitleText>{card.title}</TitleText>
+            <CheckBox onClick={() => handleCheckboxClick(card.id)}>
+              <CheckInput type="checkbox" checked={card.$isChecked} readOnly />
+              <CheckMark $isChecked={card.$isChecked}>
+                {card.$isChecked && <FaCheck />}
+              </CheckMark>
+            </CheckBox>
+          </TopContainer>
+          <TagContainer>
+            {card.tags.map((tag, index) => (
+              <Tag key={index}>{tag}</Tag>
+            ))}
+          </TagContainer>
+        </Container>
+      ))}
+    </Background>
   );
 }
 
 export default PreviewSheetCard;
 
-const Container = styled.div`
-  width: 160px;
+const Background = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+`;
 
+const Container = styled.div`
+  width: 140px;
   background-color: white;
   border-radius: 12px;
-
   border: 1px solid var(--color-light-gray);
   padding: 15px;
 `;
@@ -77,7 +108,7 @@ const CheckMark = styled.div`
   border: 1px solid var(--color-gray);
   border-radius: 4px;
   background-color: ${(props) =>
-    props.isChecked ? "var(--color-dark-blue)" : "transparent"};
+    props.$isChecked ? "var(--color-dark-blue)" : "transparent"};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -93,30 +124,16 @@ const TagContainer = styled.div`
   gap: 10px;
   margin-top: 6px;
   font-size: 10px;
-
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 `;
 
-const TitleTag = styled.div`
-  width: fit-content;
-  border-radius: 4px;
-
-  font-weight: var(--weight-bold);
-  padding: 5px;
-
-  background-color: var(--color-dark-blue);
-  color: white;
-`;
-
 const Tag = styled.div`
   width: fit-content;
   border-radius: 4px;
-
   font-weight: var(--weight-medium);
   padding: 5px;
-
   background-color: var(--color-light-blue);
   color: var(--color-navy);
 `;

--- a/src/components/write-letter/PreviewSheetCard.jsx
+++ b/src/components/write-letter/PreviewSheetCard.jsx
@@ -1,0 +1,122 @@
+import styled from "styled-components";
+import { useState } from "react";
+import { FaCheck } from "react-icons/fa6";
+
+function PreviewSheetCard() {
+  const [isChecked, setIsChecked] = useState(false);
+
+  const handleCheckboxClick = () => {
+    setIsChecked(!isChecked);
+  };
+
+  return (
+    <Container>
+      <TopContainer>
+        <TitleText>데이터 분석 워크샵</TitleText>
+        <CheckBox onClick={handleCheckboxClick}>
+          <CheckInput type="checkbox" checked={isChecked} readOnly />
+          <CheckMark isChecked={isChecked}>
+            {isChecked && <FaCheck />}
+          </CheckMark>
+        </CheckBox>
+      </TopContainer>
+      <TagContainer>
+        <TitleTag>워크샵</TitleTag>
+        <Tag>리더십</Tag>
+        <Tag>리더십</Tag>
+        <Tag>리더십</Tag>
+      </TagContainer>
+    </Container>
+  );
+}
+
+export default PreviewSheetCard;
+
+const Container = styled.div`
+  width: 160px;
+
+  background-color: white;
+  border-radius: 12px;
+
+  border: 1px solid var(--color-light-gray);
+  padding: 15px;
+`;
+
+const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TitleText = styled.p`
+  font-size: 12px;
+  font-weight: var(--weight-bold);
+`;
+
+const CheckBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+`;
+
+const CheckInput = styled.input`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+`;
+
+const CheckMark = styled.div`
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--color-gray);
+  border-radius: 4px;
+  background-color: ${(props) =>
+    props.isChecked ? "var(--color-dark-blue)" : "transparent"};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+
+  svg {
+    font-size: 10px;
+  }
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+  font-size: 10px;
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const TitleTag = styled.div`
+  width: fit-content;
+  border-radius: 4px;
+
+  font-weight: var(--weight-bold);
+  padding: 5px;
+
+  background-color: var(--color-dark-blue);
+  color: white;
+`;
+
+const Tag = styled.div`
+  width: fit-content;
+  border-radius: 4px;
+
+  font-weight: var(--weight-medium);
+  padding: 5px;
+
+  background-color: var(--color-light-blue);
+  color: var(--color-navy);
+`;

--- a/src/components/write-letter/PreviewSheetCard.jsx
+++ b/src/components/write-letter/PreviewSheetCard.jsx
@@ -22,6 +22,12 @@ function PreviewSheetCard() {
       tags: ["스터디", "개발", "협업"],
       $isChecked: false,
     },
+    {
+      id: 4,
+      title: "프로그래밍 스터디",
+      tags: ["스터디", "개발", "협업"],
+      $isChecked: false,
+    },
   ]);
 
   const handleCheckboxClick = (id) => {
@@ -61,14 +67,17 @@ export default PreviewSheetCard;
 const Background = styled.div`
   width: 100%;
   display: flex;
-  gap: 20px;
+  gap: 10px;
   flex-wrap: wrap;
+
+  justify-content: center;
 `;
 
 const Container = styled.div`
   width: 140px;
+  height: 40px;
   background-color: white;
-  border-radius: 12px;
+  border-radius: 10px;
   border: 1px solid var(--color-light-gray);
   padding: 15px;
 `;

--- a/src/components/write-letter/SheetListPanel.jsx
+++ b/src/components/write-letter/SheetListPanel.jsx
@@ -121,7 +121,7 @@ const TagContainer = styled.div`
   overflow-x: auto;
   white-space: nowrap;
 
-  padding: 20px 0;
+  padding: 5px 0;
 `;
 
 const Tag = styled.button`

--- a/src/components/write-letter/SheetListPanel.jsx
+++ b/src/components/write-letter/SheetListPanel.jsx
@@ -21,13 +21,13 @@ function SheetListPanel() {
         <ToggleContainer>
           <SelectSheet
             onClick={() => handleButtonClick("sheet")}
-            isActive={selectedButton === "sheet"}
+            $isActive={selectedButton === "sheet"}
           >
             경험시트
           </SelectSheet>
           <SelectNews
             onClick={() => handleButtonClick("news")}
-            isActive={selectedButton === "news"}
+            $isActive={selectedButton === "news"}
           >
             업계소식
           </SelectNews>
@@ -44,14 +44,16 @@ function SheetListPanel() {
         ].map((tag) => (
           <Tag
             key={tag}
-            isActive={selectedTag === tag}
+            $isActive={selectedTag === tag}
             onClick={() => handleTagClick(tag)}
           >
             {tag}
           </Tag>
         ))}
       </TagContainer>
-      <PreviewSheetCard></PreviewSheetCard>
+      <PreviewSheetList>
+        <PreviewSheetCard></PreviewSheetCard>
+      </PreviewSheetList>
     </Container>
   );
 }
@@ -91,11 +93,11 @@ const SelectSheet = styled.button`
   border-style: solid;
   border-radius: 15px 0 0 15px;
   background-color: white;
-  color: ${({ isActive }) =>
-    isActive ? "var(--color-dark-blue)" : "var(--color-black)"};
+  color: ${({ $isActive }) =>
+    $isActive ? "var(--color-dark-blue)" : "var(--color-black)"};
 
-  border-color: ${({ isActive }) =>
-    isActive ? "var(--color-dark-blue)" : "var(--color-light-gray)"};
+  border-color: ${({ $isActive }) =>
+    $isActive ? "var(--color-dark-blue)" : "var(--color-light-gray)"};
   font-weight: var(--weight-bold);
 `;
 
@@ -104,10 +106,10 @@ const SelectNews = styled.button`
   border-style: solid;
   border-radius: 0px 15px 15px 0;
   background-color: white;
-  color: ${({ isActive }) =>
-    isActive ? "var(--color-dark-blue)" : "var(--color-black)"};
-  border-color: ${({ isActive }) =>
-    isActive ? "var(--color-dark-blue)" : "var(--color-light-gray)"};
+  color: ${({ $isActive }) =>
+    $isActive ? "var(--color-dark-blue)" : "var(--color-black)"};
+  border-color: ${({ $isActive }) =>
+    $isActive ? "var(--color-dark-blue)" : "var(--color-light-gray)"};
   font-weight: var(--weight-bold);
 `;
 
@@ -132,8 +134,14 @@ const Tag = styled.button`
   font-size: 12px;
   font-weight: var(--weight-semi-bold);
 
-  background-color: ${({ isActive }) =>
-    isActive ? "var(--color-dark-blue)" : "var(--color-bg-blue)"};
-  color: ${({ isActive }) =>
-    isActive ? "var(--color-white)" : "var(--color-dark-blue)"};
+  background-color: ${({ $isActive }) =>
+    $isActive ? "var(--color-dark-blue)" : "var(--color-bg-blue)"};
+  color: ${({ $isActive }) =>
+    $isActive ? "var(--color-white)" : "var(--color-dark-blue)"};
+`;
+
+const PreviewSheetList = styled.div`
+  width: 100%;
+
+  padding: 15px 0;
 `;

--- a/src/components/write-letter/SheetListPanel.jsx
+++ b/src/components/write-letter/SheetListPanel.jsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import styled from "styled-components";
+import PreviewSheetCard from "./PreviewSheetCard";
+
+function SheetListPanel() {
+  const [selectedButton, setSelectedButton] = useState("sheet");
+  const [selectedTag, setSelectedTag] = useState("");
+
+  const handleButtonClick = (button) => {
+    setSelectedButton(button);
+  };
+
+  const handleTagClick = (tag) => {
+    setSelectedTag(tag);
+  };
+
+  return (
+    <Container>
+      <TopContainer>
+        <TitleText>경험시트 목록</TitleText>
+        <ToggleContainer>
+          <SelectSheet
+            onClick={() => handleButtonClick("sheet")}
+            isActive={selectedButton === "sheet"}
+          >
+            경험시트
+          </SelectSheet>
+          <SelectNews
+            onClick={() => handleButtonClick("news")}
+            isActive={selectedButton === "news"}
+          >
+            업계소식
+          </SelectNews>
+        </ToggleContainer>
+      </TopContainer>
+      <TagContainer>
+        {[
+          "전체(23)",
+          "책임감(23)",
+          "리더십(23)",
+          "열정(23)",
+          "창의력(23)",
+          "문제해결능력(23)",
+        ].map((tag) => (
+          <Tag
+            key={tag}
+            isActive={selectedTag === tag}
+            onClick={() => handleTagClick(tag)}
+          >
+            {tag}
+          </Tag>
+        ))}
+      </TagContainer>
+      <PreviewSheetCard></PreviewSheetCard>
+    </Container>
+  );
+}
+
+export default SheetListPanel;
+
+const Container = styled.div`
+  width: 380px;
+  height: 400px;
+
+  background-color: var(--color-bg-blue);
+  border-radius: 15px;
+  border: 0.5px solid var(--color-light-gray);
+  padding: 20px;
+`;
+
+const TitleText = styled.p`
+  font-size: 14px;
+  font-weight: var(--weight-bold);
+`;
+
+const TopContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const ToggleContainer = styled.div`
+  display: flex;
+  font-size: 12px;
+
+  overflow-x: auto;
+`;
+
+const SelectSheet = styled.button`
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 15px 0 0 15px;
+  background-color: white;
+  color: ${({ isActive }) =>
+    isActive ? "var(--color-dark-blue)" : "var(--color-black)"};
+
+  border-color: ${({ isActive }) =>
+    isActive ? "var(--color-dark-blue)" : "var(--color-light-gray)"};
+  font-weight: var(--weight-bold);
+`;
+
+const SelectNews = styled.button`
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 0px 15px 15px 0;
+  background-color: white;
+  color: ${({ isActive }) =>
+    isActive ? "var(--color-dark-blue)" : "var(--color-black)"};
+  border-color: ${({ isActive }) =>
+    isActive ? "var(--color-dark-blue)" : "var(--color-light-gray)"};
+  font-weight: var(--weight-bold);
+`;
+
+const TagContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+
+  overflow-x: auto;
+  white-space: nowrap;
+
+  padding: 20px 0;
+`;
+
+const Tag = styled.button`
+  width: fit-content;
+
+  border: 1px solid var(--color-dark-blue);
+  border-radius: 4px;
+
+  padding: 7px;
+  font-size: 12px;
+  font-weight: var(--weight-semi-bold);
+
+  background-color: ${({ isActive }) =>
+    isActive ? "var(--color-dark-blue)" : "var(--color-bg-blue)"};
+  color: ${({ isActive }) =>
+    isActive ? "var(--color-white)" : "var(--color-dark-blue)"};
+`;

--- a/src/components/write-letter/WriteLetterPage.style.js
+++ b/src/components/write-letter/WriteLetterPage.style.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+export const Background = styled.div`
+  width: 100%;
+  height: 100vh;
+
+  display: flex;
+  margin-top: 40px;
+  margin-left: 80px;
+`;
+
+export const WriteContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+
+  align-items: center;
+`;
+
+export const PanelContainer = styled.div`
+  width: 100%;
+  display: flex;
+`;

--- a/src/components/write-letter/WriteLetterPage.style.js
+++ b/src/components/write-letter/WriteLetterPage.style.js
@@ -7,6 +7,8 @@ export const Background = styled.div`
   display: flex;
   margin-top: 40px;
   margin-left: 80px;
+
+  overflow-x: hidden;
 `;
 
 export const WriteContainer = styled.div`
@@ -21,4 +23,6 @@ export const WriteContainer = styled.div`
 export const PanelContainer = styled.div`
   width: 100%;
   display: flex;
+  flex-direction: column;
+  gap: 20px;
 `;

--- a/src/pages/WriteLetterPage.jsx
+++ b/src/pages/WriteLetterPage.jsx
@@ -1,0 +1,97 @@
+import { useState, useRef } from "react";
+import LetterBox from "/src/components/write-letter/LetterBox.jsx";
+import {
+  Background,
+  WriteContainer,
+  PanelContainer,
+} from "/src/components/write-letter/WriteLetterPage.style.js";
+import SheetListPanel from "../components/write-letter/SheetListPanel";
+import IndexNavigator from "../components/write-letter/IndexNavigator";
+
+function WriteCoverLetterPage() {
+  const [letters, setLetters] = useState([
+    {
+      id: 1,
+      title: "1. 지원동기 및 포부",
+      subText:
+        "기업명을 선택한 이유와 입사 후 회사에서 이루고 싶은 꿈을 기술하십시오.",
+      text: "",
+      maxLength: 300,
+    },
+    {
+      id: 2,
+      title: "2. 직무역량",
+      subText:
+        "[기업명] 해당 직무 분야에 지원하게 된 이유와 선택 직무에 본인이 적합하다고 판단할 수 있는 이유 및 근거를 제시해주십시오.",
+      text: "",
+      maxLength: 300,
+    },
+    {
+      id: 3,
+      title: "3. 도전 (성공 / 실패)",
+      subText:
+        "[기업명] 학업 외 가장 열정적이고 도전적으로 몰입하여 성과를 창출했거나 목표를 달성한 경험을 알려주세요.",
+      text: "",
+      maxLength: 300,
+    },
+    {
+      id: 4,
+      title: "4. 창의성 (문제해결능력)",
+      subText:
+        "[기업명] 남들과 다른 새로운 관점으로 변화/ 혁신을 추구한 경험과 그를 통해 배운점이 있나요?",
+      text: "",
+      maxLength: 300,
+    },
+    {
+      id: 5,
+      title: "5. 팀워크 / 협업",
+      subText:
+        "[기업명] 공동의 목표를 달성하기 위해 타인과 협업했던 경험과 그 과정에서 본인이 수행한 역할, 그리고 해당 경험을 통해 얻은 것은 무엇인가요?",
+      text: "",
+      maxLength: 300,
+    },
+  ]);
+
+  // 각 LetterBox를 참조하는 배열 생성
+  const sectionRefs = useRef([]);
+
+  const handleTextChange = (id, newText) => {
+    setLetters((prev) =>
+      prev.map((letter) =>
+        letter.id === id ? { ...letter, text: newText } : letter
+      )
+    );
+  };
+
+  const handleNavigate = (id) => {
+    const section = sectionRefs.current[id - 1];
+    if (section) {
+      section.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  return (
+    <Background>
+      <IndexNavigator onNavigate={handleNavigate} />
+      <WriteContainer>
+        {letters.map((letter, index) => (
+          <div key={letter.id} ref={(el) => (sectionRefs.current[index] = el)}>
+            <LetterBox
+              title={letter.title}
+              placeholder={letter.placeholder}
+              subText={letter.subText}
+              text={letter.text}
+              maxLength={letter.maxLength}
+              onChange={(newText) => handleTextChange(letter.id, newText)}
+            />
+          </div>
+        ))}
+      </WriteContainer>
+      <PanelContainer>
+        <SheetListPanel />
+      </PanelContainer>
+    </Background>
+  );
+}
+
+export default WriteCoverLetterPage;

--- a/src/pages/WriteLetterPage.jsx
+++ b/src/pages/WriteLetterPage.jsx
@@ -52,7 +52,6 @@ function WriteCoverLetterPage() {
     },
   ]);
 
-  // 각 LetterBox를 참조하는 배열 생성
   const sectionRefs = useRef([]);
 
   const handleTextChange = (id, newText) => {
@@ -63,6 +62,7 @@ function WriteCoverLetterPage() {
     );
   };
 
+  // 목차 클릭 시 특정 세션으로 스크롤
   const handleNavigate = (id) => {
     const section = sectionRefs.current[id - 1];
     if (section) {

--- a/src/pages/WriteLetterPage.jsx
+++ b/src/pages/WriteLetterPage.jsx
@@ -7,6 +7,7 @@ import {
 } from "/src/components/write-letter/WriteLetterPage.style.js";
 import SheetListPanel from "../components/write-letter/SheetListPanel";
 import IndexNavigator from "../components/write-letter/IndexNavigator";
+import DetailPanel from "../components/write-letter/DetailPanel";
 
 function WriteCoverLetterPage() {
   const [letters, setLetters] = useState([
@@ -89,6 +90,7 @@ function WriteCoverLetterPage() {
       </WriteContainer>
       <PanelContainer>
         <SheetListPanel />
+        <DetailPanel />
       </PanelContainer>
     </Background>
   );


### PR DESCRIPTION
### ✨ PR Type
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] etc


### 📜 작업 내용
- 경험시트 작성 페이지 UI 퍼블리싱
- 헤더 메뉴 '채용공고' → '경험시트'로 수정
- 좌측 목록 클릭 시 스크롤 이동 기능 구현


### ✅ 테스트

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/f01093e8-da02-47f1-8bef-6679274ae005">

### 📮 ETC

이후 헤더 아래에 고정되어있는 서브 헤더 + 추가적인 UI 수정 + 
경험시트 목록에서 체크박스 클릭 시 LetterBox에 보여주는 기능 구현 할 예정입니다!

---
#### 반영 브랜치
ex) feat/cover-letter -> develop